### PR TITLE
Fix a fatal error on some pages when Buddyboss plugin is installed.

### DIFF
--- a/workshop-butler/includes/class-wsb-integration.php
+++ b/workshop-butler/includes/class-wsb-integration.php
@@ -200,7 +200,7 @@ class WSB_Integration {
 		if ( ! is_admin() ) {
 			$this->loader->add_action( 'init', $plugin_public, 'init' );
 			$this->loader->add_filter( 'pre_get_document_title', $plugin_public, 'set_document_title', 99 );
-			$this->loader->add_filter( 'the_title', $plugin_public, 'set_title', 10, 2 );
+			$this->loader->add_filter( 'the_title', $plugin_public, 'set_title', 10 );
 			// Yoast SEO hooks
 			$this->loader->add_filter( 'wpseo_frontend_presenter_classes', $plugin_public, 'wpseo_frontend_presenters', 10, 1 );
 			$this->loader->add_filter( 'wpseo_opengraph_title', $plugin_public, 'set_document_title');

--- a/workshop-butler/public/class-wsb-integration-public.php
+++ b/workshop-butler/public/class-wsb-integration-public.php
@@ -141,12 +141,11 @@ class WSB_Integration_Public {
 	 * Updates the title of the page
 	 *
 	 * @param string $title Current page title.
-	 * @param int    $id ID of the page.
 	 *
 	 * @return string
 	 * @since 2.0.0
 	 */
-	public function set_title( $title, $id ) {
+	public function set_title( $title ) {
 		$options      = new WSB_Options();
 		$reserved_ids = array(
 			intval( $options->get( WSB_Options::EVENT_PAGE ) ),
@@ -154,7 +153,8 @@ class WSB_Integration_Public {
 			intval( $options->get( WSB_Options::TRAINER_PROFILE_PAGE ) ),
 		);
 
-		if ( in_array( $id, $reserved_ids, true ) ) {
+		$id = get_the_ID();
+		if ( is_int( $id ) && in_array( $id, $reserved_ids, true ) ) {
 			return $this->get_title( $title );
 		} else {
 			return $title;

--- a/workshop-butler/readme.txt
+++ b/workshop-butler/readme.txt
@@ -68,6 +68,9 @@ Please, open an issue [here](https://github.com/workshopbutler/wordpress-plugin)
 Please, open an issue [here](https://github.com/workshopbutler/wordpress-plugin)
 
 == Changelog ==
+= 2.13.6 =
+* Fixes a fatal error happening on some pages when Buddyboss is installed
+
 = 2.13.5 =
 * Fixes translations and support for Macedonian, Hungarian and Hebrew languages
 

--- a/workshop-butler/workshop-butler.php
+++ b/workshop-butler/workshop-butler.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://github.com/workshopbutler/wordpress-plugin
  * Description:       This plugin integrates Workshop Butler Events, Trainers and Testimonials to your WordPress
  *     website.
- * Version:           2.13.5
+ * Version:           2.13.6
  * Author:            Workshop Butler
  * Author URI:        https://workshopbutler.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version.
  */
-define( 'WSB_INTEGRATION_VERSION', '2.13.5' );
+define( 'WSB_INTEGRATION_VERSION', '2.13.6' );
 
 /**
  * Version of Workshop Butler API, used by this plugin


### PR DESCRIPTION
The error: Uncaught Error: Too few arguments to function WorkshopButler\WSB_Integration_Public::set_title(), 1 passed in .../wp-includes/class-wp-hook.php on line 287 and exactly 2 expected

in /wp-content/plugins/workshop-butler/public/class-wsb-integration-public.php on line 149

Call stack:

WorkshopButler\WSB_Integration_Public::set_title()
wp-includes/class-wp-hook.php:287
WP_Hook::apply_filters()
wp-includes/plugin.php:212
apply_filters()
wp-content/plugins/buddyboss-platform/bp-forums/core/theme-compat.php:529
bbp_template_include_theme_compat()
wp-includes/class-wp-hook.php:287
WP_Hook::apply_filters()
wp-includes/plugin.php:212
apply_filters()
wp-content/plugins/buddyboss-platform/bp-forums/core/sub-actions.php:446
bbp_template_include()
wp-includes/class-wp-hook.php:287
WP_Hook::apply_filters()
wp-includes/plugin.php:212
apply_filters()
wp-includes/template-loader.php:104
require_once()
wp-blog-header.php:19
require()
index.php:17