### PR TITLE
2.13.7

### DIFF
--- a/workshop-butler/includes/class-wsb-integration.php
+++ b/workshop-butler/includes/class-wsb-integration.php
@@ -200,7 +200,7 @@ class WSB_Integration {
 		if ( ! is_admin() ) {
 			$this->loader->add_action( 'init', $plugin_public, 'init' );
 			$this->loader->add_filter( 'pre_get_document_title', $plugin_public, 'set_document_title', 99 );
-			$this->loader->add_filter( 'the_title', $plugin_public, 'set_title', 10 );
+			$this->loader->add_filter( 'the_title', $plugin_public, 'set_title', 10, 2 );
 			// Yoast SEO hooks
 			$this->loader->add_filter( 'wpseo_frontend_presenter_classes', $plugin_public, 'wpseo_frontend_presenters', 10, 1 );
 			$this->loader->add_filter( 'wpseo_opengraph_title', $plugin_public, 'set_document_title');

--- a/workshop-butler/public/class-wsb-integration-public.php
+++ b/workshop-butler/public/class-wsb-integration-public.php
@@ -141,20 +141,19 @@ class WSB_Integration_Public {
 	 * Updates the title of the page
 	 *
 	 * @param string $title Current page title.
+	 * @param int    $id ID of the page.
 	 *
 	 * @return string
 	 * @since 2.0.0
 	 */
-	public function set_title( $title ) {
+	public function set_title( $title, $id = null ) {
 		$options      = new WSB_Options();
 		$reserved_ids = array(
 			intval( $options->get( WSB_Options::EVENT_PAGE ) ),
 			intval( $options->get( WSB_Options::REGISTRATION_PAGE ) ),
 			intval( $options->get( WSB_Options::TRAINER_PROFILE_PAGE ) ),
 		);
-
-		$id = get_the_ID();
-		if ( is_int( $id ) && in_array( $id, $reserved_ids, true ) ) {
+		if ( in_array( $id, $reserved_ids, true ) ) {
 			return $this->get_title( $title );
 		} else {
 			return $title;

--- a/workshop-butler/readme.txt
+++ b/workshop-butler/readme.txt
@@ -68,6 +68,9 @@ Please, open an issue [here](https://github.com/workshopbutler/wordpress-plugin)
 Please, open an issue [here](https://github.com/workshopbutler/wordpress-plugin)
 
 == Changelog ==
+= 2.13.7 =
+* Rolls back the changes from the previous fix and uses another way to fix a fatal error with Buddyboss
+
 = 2.13.6 =
 * Fixes a fatal error happening on some pages when Buddyboss is installed
 

--- a/workshop-butler/workshop-butler.php
+++ b/workshop-butler/workshop-butler.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://github.com/workshopbutler/wordpress-plugin
  * Description:       This plugin integrates Workshop Butler Events, Trainers and Testimonials to your WordPress
  *     website.
- * Version:           2.13.6
+ * Version:           2.13.7
  * Author:            Workshop Butler
  * Author URI:        https://workshopbutler.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version.
  */
-define( 'WSB_INTEGRATION_VERSION', '2.13.6' );
+define( 'WSB_INTEGRATION_VERSION', '2.13.7' );
 
 /**
  * Version of Workshop Butler API, used by this plugin


### PR DESCRIPTION
Roll back the previous fix as it made the things worse (it replaces all labels in menus) and find a new solution
 for Buddyboss error