### PR TITLE
Fix for '$' method not defined for jQuery in some cases

### DIFF
--- a/workshop-butler/public/js/registration-page.js
+++ b/workshop-butler/public/js/registration-page.js
@@ -306,7 +306,7 @@ var EventRegistrationForm = /*#__PURE__*/function () {
   };
 
   _proto._onChangeAgreed = function _onChangeAgreed(e) {
-    var isAgreedForm = $(e.currentTarget).prop('checked');
+    var isAgreedForm = jQuery(e.currentTarget).prop('checked');
     this.locals.$btnSubmit.prop('disabled', !isAgreedForm);
   };
 
@@ -559,7 +559,7 @@ var EventRegistrationForm = /*#__PURE__*/function () {
 
   _proto._sendFormData = function _sendFormData(url, data) {
     data._ajax_nonce = wsb_event.nonce;
-    return $.ajax({
+    return jQuery.ajax({
       url: url,
       data: data,
       method: 'POST',
@@ -571,7 +571,7 @@ var EventRegistrationForm = /*#__PURE__*/function () {
     var $elems = jQuery(selector);
     if (!$elems.length) return;
     return $elems.each(function (index, el) {
-      var $element = $(el);
+      var $element = jQuery(el);
       var data = $element.data('widget.server.detail');
 
       if (!data) {

--- a/workshop-butler/readme.txt
+++ b/workshop-butler/readme.txt
@@ -68,6 +68,9 @@ Please, open an issue [here](https://github.com/workshopbutler/wordpress-plugin)
 Please, open an issue [here](https://github.com/workshopbutler/wordpress-plugin)
 
 == Changelog ==
+= 2.13.8 =
+* Fixes a JS error on the registration form when jQuery doesn't work in some rare cases
+
 = 2.13.7 =
 * Rolls back the changes from the previous fix and uses another way to fix a fatal error with Buddyboss
 

--- a/workshop-butler/workshop-butler.php
+++ b/workshop-butler/workshop-butler.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://github.com/workshopbutler/wordpress-plugin
  * Description:       This plugin integrates Workshop Butler Events, Trainers and Testimonials to your WordPress
  *     website.
- * Version:           2.13.7
+ * Version:           2.13.8
  * Author:            Workshop Butler
  * Author URI:        https://workshopbutler.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version.
  */
-define( 'WSB_INTEGRATION_VERSION', '2.13.7' );
+define( 'WSB_INTEGRATION_VERSION', '2.13.8' );
 
 /**
  * Version of Workshop Butler API, used by this plugin


### PR DESCRIPTION
In some cases, '$' is not defined, only jQuery. Some time ago I replaces $ requests with jQuery one, but not everywhere. 

Please, take a look and test the registration form functionality. 